### PR TITLE
Feature/trim indel ends

### DIFF
--- a/scripts/trim_indel_ends.md
+++ b/scripts/trim_indel_ends.md
@@ -1,0 +1,54 @@
+# Trim indel ends
+
+## Description
+This program looks at pair-wise isoform alignments within each window and trims off beginning and ending of isoforms to reduce false posistives.
+
+## Help message
+`python scripts/trim_indel_ends.py manifest unique_isoform_aln [-m mode -t threshold]`
+
+```
+- manifest -- manifest file in form <sample,in/fasta.fa> that describes the sample and location of fasta files
+- unique_isoform_aln -- output from `find_unique_isoform.py`
+- mode -- optional -- "strict" or "lenient"
+    - "strict" will only trim if after trimming, two isoforms are exactly the same
+    - "lenient" will trim whenever indels are encountered at the ends of the alignment
+    - Default is "lenient"
+- threshold -- optional -- maximum number of bases to be trimmed off each end. Default is 10000 (no limit)
+```
+
+## Input
+- fasta files for each sample
+- `unique_isoform_and_aln_stats.tsv` produced by `find_unique_isoform.py`
+
+## Output
+- separate sample fasta files
+- Histogram describing trim lengths
+- Scatter plot describing edit distance before and after trimmming
+
+## Logic
+1. For each isoform present in `unique_isoform_and_aln_stats.tsv`, this program first finds the isoform in another sample that is the most similar to it. 
+
+2. Then, this program looks at the cigar string of each pair of sequences. 
+    - If the cigar string starts or ends with insertions `"I"` or deletions `"D"`, the program trims the sequences.
+        - Trim the first-in-pair if `"I"` is encountered
+        - Trim the second-in-pair if `"D"` is encountered
+3. Write sequences in separate sample fasta files
+    - If a sequence is trimmed in multiple pairs, keep the longest one
+    - If a sequence is not included in `unique_isoform_and_aln_stats.tsv`, look for it in original fasta and include it.
+
+## Dependencies
+```
+import pandas as pd
+from collections import defaultdict, Counter
+import re
+import edlib
+from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
+from Bio.Seq import Seq
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+import os
+import sys
+import argparse
+import datetime
+```

--- a/scripts/trim_indel_ends.py
+++ b/scripts/trim_indel_ends.py
@@ -4,12 +4,24 @@
     Date: Nov 20
     Description: For each pair of alinment between reads, if the best alignment includes indels at the beginning and ends
         of the reads, then trim off the indels.
-    Output: new set of reads for each sample.
+    Input: 
+        - old sets of reads for each sample
+        - aln_stats
+    Output: 
+        - new set of reads for each sample.
+
+    Trimming logic alternatives:
+        - Trim prefix and suffix regardless of the rest of the alignment --- set a threshold
+        - Trim prefix and suffix only when the rest of the alignment is all matches --- set a threshold
 """
 
 import pandas as pd
 from collections import defaultdict, Counter
 import re
+import edlib
+from Bio import SeqIO
+import matplotlib.pyplot as plt
+from tqdm import tqdm
 
 def extract_edits(cigar_str) -> list:
     """Given a cigar string, return separated edits with counts
@@ -37,7 +49,36 @@ def ed_from_cigar(cigar_str) -> int:
     match_count = sum([e[0] for e in all_edits if e[1] == "="])
     return total_length - match_count
 
+def get_len_type(indel_list:list) -> tuple[str, str]:
+    """Given a list of indels, return the total length and type
+
+    Args:
+        indel_list (list): list of indels
+
+    Returns:
+        tuple[str, str]: type, length
+    """
+
+    indel_type = ""
+    indel_length = 0
+    if len(indel_list) != 0:
+        for edit in indel_list:
+            if indel_type != "":
+                assert indel_type == edit[-1]
+            else:
+                indel_type = edit[-1]
+            indel_length += edit[0]
+    return indel_type, indel_length
+
 def get_prefix_and_suffix_indels(cigar_str:str) -> tuple:
+    """Get indel edits from the prefix and suffix of the cigar string
+
+    Args:
+        cigar_str (str): cigar string
+
+    Returns:
+        tuple: (list, list): prefix list of indels and suffix list of indels
+    """
     all_edits = extract_edits(cigar_str)
     prefix_indels = []
     suffix_indels = []
@@ -49,9 +90,11 @@ def get_prefix_and_suffix_indels(cigar_str:str) -> tuple:
         if all_edits[i][-1] != "I" and all_edits[i][-1] != "D":
             break
         suffix_indels.append(all_edits[i])
-    return prefix_indels, suffix_indels
 
-def trim_seq(prefix_type, prefix_len, suffix_type, suffix_len, seq, num) -> str:
+    # return prefix_indels, suffix_indels[::-1]
+    return get_len_type(prefix_indels), get_len_type(suffix_indels[::-1])
+
+def trim_seq(prefix_type, prefix_len, suffix_type, suffix_len, seq, num, threshold=10) -> str:
     """Trim input sequence according to suffix and prefix number of indels
 
     Args:
@@ -62,25 +105,26 @@ def trim_seq(prefix_type, prefix_len, suffix_type, suffix_len, seq, num) -> str:
         seq (str): input sequence to be trimmed
         num (int): ranking of the sequence. If a sequence is the first in alignment, deletion means that removing. 
         Otherwise, insertion means trimming.
+        threshold (int): maximum number of bases trimmed
 
     Returns:
         str: trimmed sequence
     """
     assert num == 1 or num == 2, "trim_seq(): unknown ranking of input sequence!"
 
-    if num == 1:
+    if num == 2:
         if prefix_type == "D":
-            seq = seq[prefix_len:]
+            seq = seq[min(threshold, prefix_len):]
         if suffix_type == "D":
-            seq = seq[:-suffix_len]
+            seq = seq[:-min(threshold, suffix_len)]
     if num == 1:
         if prefix_type == "I":
-            seq = seq[prefix_len:]
+            seq = seq[min(threshold, prefix_len):]
         if suffix_type == "I":
-            seq = seq[:-suffix_len]
+            seq = seq[:-min(threshold, suffix_len)]
     return seq
 
-def trim_from_cigar(cigar_str, sequence1, sequence2):
+def trim_from_cigar(cigar_str, sequence1, sequence2, threshold=10):
     """Given two sequences and the cigar string describing the alignment between them, trim the start and end, if the 
     alignment starts and/or ends with indels.
 
@@ -88,135 +132,167 @@ def trim_from_cigar(cigar_str, sequence1, sequence2):
         cigar_str (str): cigar_string
         sequence1(str): aligned sequence 1 to be trimmed
         sequence2(str): aligned sequence 2 to be trimmed
+        threshold(int): maximum number of bases trimmed
     Returns:
         str: trimmed sequence 1
         str: trimmed sequence 2
     """
 
-    prefix_indels, suffix_indels = get_prefix_and_suffix_indels(cigar_str)
+    (prefix_type, prefix_length), (suffix_type, suffix_length) = get_prefix_and_suffix_indels(cigar_str)
 
-    if len(prefix_indels) == 0 and len(suffix_indels) == 0:
+    if prefix_length == 0 and suffix_length == 0:
         return sequence1, sequence2
+
     global total_trim
     total_trim += 1
-    # print("Prefix and suffix indels:", prefix_indels, suffix_indels)
 
-    # print("Before trimming:", len(sequence1), len(sequence2))
-
-    prefix_type = ""
-    prefix_length = 0
-    if len(prefix_indels) != 0:
-        for edit in prefix_indels:
-            if prefix_type != "":
-                assert prefix_type == edit[-1]
-            else:
-                prefix_type = edit[-1]
-            prefix_length += len(edit[:-1])
-
-    suffix_type = ""
-    suffix_length = 0
-    if len(suffix_indels) != 0:
-        for edit in suffix_indels:
-            if suffix_type != "":
-                assert suffix_type == edit[-1]
-            else:
-                suffix_type = edit[-1]
-            suffix_length += len(edit[:-1])
-
-    sequence1 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence1, 1)
-    sequence2 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence2, 2)
+    sequence1 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence1, 1, threshold)
+    sequence2 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence2, 2, threshold)
 
     global correct_trim
-    if len(sequence1) == len(sequence2):
+    if len(sequence1) == len(sequence2) and sequence1 == sequence2:
         correct_trim += 1
-
-    # print("After trimming:", len(sequence1), len(sequence2))
 
     return sequence1, sequence2
 
     
+def read_fasta(fname:str, sample_name:str, seq_dict:dict) -> dict:
+    """Parse fasta file. add sequences to input sequence dict
+
+    Args:
+        fname (str): bam file name
+        sample_name(str): sample name
+        seq_dict(dict): input and output dict
+
+    Returns:
+        dict: dictionary matching read name to sequence
+    """
+    fasta_sequences = SeqIO.parse(open(fname),'fasta')
+    for fasta in tqdm(fasta_sequences):
+        name, sequence = fasta.id, str(fasta.seq)
+        seq_dict[sample_name + "_" + name] = sequence
+    return seq_dict
 
 total_trim = 0
-
-input_dir = "/Users/yutongq/SVHackathon2022/"
-fname = input_dir+"unique_isoforms_and_aln_stats.tsv"
-
-
-"""Header
-    win_chr
-    win_start
-    win_end
-    total_isoform
-    isoform_name
-    sample_from
-    sample_compared_to
-    mapped_start
-    isoform_sequence
-    selected_alignments
-"""
-aln_stats_df = pd.read_csv(fname, sep="\t").dropna()
-
-'''
-    For each sample:
-        for each read in sample:
-            will there be multiple reads that are associated with each other?
-'''
-
-records = aln_stats_df.to_dict("records")
-
-unique_read_pairs = defaultdict(dict)             # {read_id1: {read_id2: edit distance}}
-read_pair_cigar = defaultdict(dict)               # {read_id1: {read_id2: cigar_string}}
-read_sequence = dict()                            # {read_id: sequence}
-
-for record in records:
-    read_id = record["sample_from"] + "_" + record["isoform_name"]
-    compared_to= "_".join(record["selected_alignments"].split("_")[1:3])
-    cigar = record["selected_alignments"].split("_")[-1]
-
-    read_sequence[read_id] = record["isoform_sequence"]
-
-    # # check if read_id, compared_to pair is already accounted for.
-    # if compared_to in unique_read_pairs and read_id in unique_read_pairs[compared_to]:
-    #     continue
-
-    if compared_to not in unique_read_pairs[read_id]:
-        read_pair_cigar[read_id][compared_to] = cigar
-        unique_read_pairs[read_id].add(compared_to)
-
-multi_pair = Counter()
-unique_pair_cigar = defaultdict(dict)
-
 correct_trim = 0
 
-# print(read_pair_cigar)
-for read_id in unique_read_pairs:
-    multi_pair[len(unique_read_pairs[read_id])] += 1
+def main():
+    input_dir_aln = "/Users/yutongq/SVHackathon2022/isocomp/data/"
+    input_dir_fasta = "/Users/yutongq/SVHackathon2022/"
 
-    if len(unique_read_pairs[read_id]) == 1:
-        for compared_to in unique_read_pairs[read_id]:
-                cigar = read_pair_cigar[read_id][compared_to]
-                seq1 = read_sequence[read_id]
-                try:
-                    seq2 = read_sequence[compared_to]
-                except KeyError:
-                    break
-                new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2)
-                old_ed = ed_from_cigar(read_pair_cigar[read_id][compared_to])
-                ## TODO new_ed = 
-                break
+    aln_fname = input_dir_aln+"unique_isoforms_and_aln_stats.tsv"
+    fasta_1_fname = input_dir_fasta+"HG002_MM2_corrected.fasta"
+    fasta_2_fname = input_dir_fasta+"HG004_MM2_corrected.fasta"
+    fasta_3_fname = input_dir_fasta+"HG005_MM2_corrected.fasta"
 
+    read_sequence = dict()
 
-print("total trim:", total_trim)
-print("Correct trim:", correct_trim)
+    print("Parsing fasta files...")
+    read_sequence = read_fasta(fasta_1_fname, "HG002", read_sequence)
+    read_sequence = read_fasta(fasta_2_fname, "HG004", read_sequence)
+    read_sequence = read_fasta(fasta_3_fname, "HG005", read_sequence)
 
+    aln_stats_df = pd.read_csv(aln_fname, sep="\t").dropna()
+    aln_records = aln_stats_df.to_dict("records")
+
+    unique_read_pairs = defaultdict()
+    unique_read_pairs_ed = defaultdict(dict)          # {read_id1: {read_id2: edit distance}}
+    read_pair_cigar = defaultdict(dict)               # {read_id1: {read_id2: cigar_string}}
+
+    print("Parsing read comparisons...")
+    for record in tqdm(aln_records):
+        read_id = record["sample_from"] + "_" + record["isoform_name"]
+        selected_alignments = record["selected_alignments"].split(",")
+        for alignment in selected_alignments:
+            compared_to= alignment.split("__")[1]
+
+            # # store a pair only once
+            if compared_to in unique_read_pairs_ed and read_id in unique_read_pairs_ed[compared_to]:
+                continue
+
+            cigar = alignment.split("_")[-1]
+
+            read_pair_cigar[read_id][compared_to] = cigar
+            ed = edlib.align(read_sequence[read_id], read_sequence[compared_to])["editDistance"]
+            unique_read_pairs_ed[read_id][compared_to] = ed
+
+            # if a read is matched with multiple reads, keep only the most similar pair
+            if read_id in unique_read_pairs:
+                opt_compared_to = unique_read_pairs[read_id]
+                if ed < unique_read_pairs_ed[read_id][opt_compared_to]:
+                    unique_read_pairs[read_id] = compared_to
+            else:
+                unique_read_pairs[read_id] = compared_to
+
+    print("Trimming...")
+
+    old_eds = []
+    new_eds = []
+    length_diff1 = []
+    length_diff2 = []
+
+    processed_read = set()
+    for read_id in tqdm(unique_read_pairs):
+        compared_to = unique_read_pairs[read_id]
+        cigar = read_pair_cigar[read_id][compared_to]
+
+        seq1 = read_sequence[read_id]
+        seq2 = read_sequence[compared_to]
+        new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2, threshold=100000)
+        old_ed = ed_from_cigar(read_pair_cigar[read_id][compared_to])
+        new_align = edlib.align(new_seq1, new_seq2,mode = "NW", task = "path" )
+        new_ed = new_align['editDistance']
+        new_cigar = new_align["cigar"]
+
+        if seq1 != new_seq1 or seq2 != new_seq2:
+            old_eds.append(old_ed)
+            new_eds.append(new_ed)
+            if new_ed == 0:
+                length_diff1.append(abs(len(seq1) - len(new_seq1)))
+                length_diff1.append(abs(len(seq2) - len(new_seq2)))
+            else:
+                length_diff2.append(abs(len(seq1) - len(new_seq1)))
+                length_diff2.append(abs(len(seq2) - len(new_seq2)))
+        processed_read.add(read_id)
+        processed_read.add(compared_to)
 
     
+    # for read_id in read_sequence:
+    #     if read_id not in processed_read:
+    #         print(read_id)
 
-    # if len(unique_read_pairs[r]) > 1:
-    #     eds = []
-    #     for compared_to in unique_read_pairs[r]:
-    #         print(r,compared_to+",")
-    #         ed = ed_from_cigar(read_pair_cigar[r][compared_to])
-    #         eds.append(ed)
-    #     print(eds)
-print("Multi pair", multi_pair)
+        # print("Length:", len(seq1), len(seq2), len(new_seq1), len(new_seq2))
+
+    print("Total reads:", len(read_sequence))
+    print("Total pairs:", len(unique_read_pairs))
+    print("Total trim:", total_trim)
+    print("Correct trim:", correct_trim)
+
+    fig, ax = plt.subplots(1)
+    ax.scatter(old_eds, new_eds, s=5)
+    ax.plot([0, max(old_eds)], [0, max(old_eds)], color="red")
+    ax.set_xlabel("original edit distance")
+    ax.set_ylabel("timmed edit distance")
+    ax.set_title("Edit distance before and after trimming")
+    fig.savefig("ED_trim.png")
+
+
+    fig,ax = plt.subplots(1)
+    ax.hist(length_diff1, range=[0,100],bins=100)
+    ax.hist(length_diff2, range=[0,100],bins=100, alpha=0.5)
+
+    fig.savefig("ED_trim_length.png")
+
+if __name__ == "__main__":
+    main()
+
+    # seq1="GTCTTTCCTCATTTACAGCTAGCTCTGCCAGTCTGTGTCTTTGCTGTGTCTGTGGATGTGAGTGTCCCTGCTGGTCTGTAGGAGATGGTATTTTGGGGGCAGCTGCAAGGGAAAAAACTGATCTGCTACTTACACAGCGCCGTAGCCTCAGCCTGAGGGTCTTCAGGTTCTCCCCCAGGGAGTTCACATGCGCCTTGATGTCTGGGTCTTGGTTCTCAGCTTGGGGCATCACCTCCTCCAGGTAAAACTGGATCATCTCAGACAAGGCTTGGCAACCCAGGTAACCCTAAGGGCAGGAGCCAAAGAGCGGTGCTTGCACACACTGACAGGAGTCCAAGAATGTGCACTGAGGGAGCGTTTCCGCACAGATCTGCGTGTTCCTTACCACTCACACATGTGCACACACATATCCATGTGTGTGTGCCAGTGCTTTGGGGCTCTGTTCCACGGGGTGCAAACCCTAGACGAAAAAAGACTGTAATTCAACTCTTCAGTAGCCAGGATTGCCTGTCTCCAACCCCTTCTGAATCTAGTTATGTTGGATACTGGGAGAGAAGCATGTAGACTCTTTGGGCCTGACCTTTCTGATTTTTCTCTGGAAGGGCTTCACTGAAGGGGCACAGAAGAATAATGTTTCTACAGCATAGATCCAGGGGCTCCTCCCCACCAGGAACCCAGCTTAGCAGGCAGGCTGTTCATGTGGAACTCGCCAAAACCCCGTGCAGGTGGATGTGCGGAAACACCAAAGAACTGCACGATTGTCCCTGCCTTTGGAAGGTCTCATTCCCTGTCATTCCTTCATTCAGTCAACAAACTTGGAGGACCCAGTATGTGCTACATTTTGAGGATAAAGTGATGAACAACACAGACAAGATCCCTGCCCTTGTGGAGTCTATATTCAAACCAGAGCTTGACCTTCAAACTGAGAGACCAACTTAAAAATGGGGCCATCTGGCCACTAACTGTTATACACCCTCTGCTTGGGACACACGGTCTCAGCCCTCCTCCACCTTCAAGTCTGATAGGAGAGAGATTTCAGAGTGGCCCAAACAATCTAAAGTAAAAGTGAACAGAGTTCAAAATAAGTCCTCAAGGGCTGAGGGGAGACCAAGGGGAAGATAATGCGGTGAGGGCACTGAGAGAGGGATTCCTAGAGGAATTGTACCTTGCTTTGAATTTTAGCCCTAAGCTGCAAATCCTAGCTAACTTCTAAGTAGATGCTGACAGCTGGCTTCTATTTGGTCTGCCATATTGAATGGCTTTGTCCCCAGGACATGGTGGAGATTTAGACAACCCAGGGCAGAAAATCCTCTAGGAAAGGAAGTCTGAACTACACCGCTGGCTTTCTGAAAGGACAGGATTTGAGGAGCTGGGATGGTAGTAGGGGAGAGGGCAGCTGGGTGGGGTTTCTTCCAGGAAACAATGTGGATGCAAGATGCAGTCCTCGTCCCTGGCCTGCCCTTACCGCTTTAGTATTTCAGATGAGTCAGCTCTCACTCTGCCACCTGCTTTCTGTAACTCTGCAGCAGGCCAGCAGCCTCCAGTCCACCCTCTCCTCCTCCCAGGGCTCTGGGGTGAAGCCCTCCCCAGGAACTCCCTGGCTCCCAGTACCCATGGGAGAAGCTCTTTTCAACTGACATGATTTATTTTAACAATAAGAGGAAAAAACCACATCCGATTTCCACAGAATTAGAGTTCCTCCTGACACGCCTGGACTTGCCAGTTGGGAAGGACACTCTCAAGCCATCCTCTATGCCATTTGCCGTTCTGCTGTTCCTTTGCTTGGAGGGAAGAGATGCCTGTTTCTATAGGGAGGAAGTTTGAAGTGAGAAGAGAGGACAAAGATTCTGTGAATGGAAAGAGCACTGGACTGAGAGTTCAGGGATGTGGCCTCCGGTCCCAGCTCCACCACTACTCAGTTGTCTGACGAAGGAAACAGAAAGTTGTGATACAATGTGGGTGACACATTGCCTAGAAAGAAGTGCCGTTGTGATACGCTTATGTTGGTGGGATGGGGGAAAGAAATAACAGGTTTGTATGGAGTGTTATGAAAGAATTAAATCTTAACCTTCCATTGGGGTAAGCTGATGGAAACAACCATAGCAAAGGACAGACTGAATATTTTTTTATTCTCTTTATAGAAAATAACAGTAAAAAAAAGTATTGACATAGGAGAAGGAAACAAAAAGTTGTCAGGAGTTAATGAATAGAAATATTATTTTTTTCTGGATTTTATGGTGTTTGTGTTATTTGTTAGCTTTTATGAATTTGTAATTTGTTGTAATTTCTTTCTAAATAAGTATTTACTTTTGTCTCT"
+
+    # seq2 = "TAGCTCTGCCAGTCTGTGTCTTTGCTGTGTCTGTGGATGTGAGTGTCCCTGCTGGTCTGTAGGAGATGGTATTTTGGGGGCAGCTGCAAGGGAAAAAACTGATCTGCTACTTACACAGCGCCGTAGCCTCAGCCTGAGGGTCTTCAGGTTCTCCCCCAGGGAGTTCACATGCGCCTTGATGTCTGGGTCTTGGTTCTCAGCTTGGGGCATCACCTCCTCCAGGTAAAACTGGATCATCTCAGACAAGGCTTGGCAACCCAGGTAACCCTAAGGGCAGGAGCCAAAGAGCGGTGCTTGCACACACTGACAGGAGTCCAAGAATGTGCACTGAGGGAGCGTTTCCGCACAGATCTGCGTGTTCCTTACCACTCACACATGTGCACACACATATCCATGTGTGTGTGCCAGTGCTTTGGGGCTCTGTTCCACGGGGTGCAAACCCTAGACGAAAAAAGACTGTAATTCAACTCTTCAGTAGCCAGGATTGCCTGTCTCCAACCCCTTCTGAATCTAGTTATGTTGGATACTGGGAGAGAAGCATGTAGACTCTTTGGGCCTGACCTTTCTGATTTTTCTCTGGAAGGGCTTCACTGAAGGGGCACAGAAGAATAATGTTTCTACAGCATAGATCCAGGGGCTCCTCCCCACCAGGAACCCAGCTTAGCAGGCAGGCTGTTCATGTGGAACTCGCCAAAACCCCGTGCAGGTGGATGTGCGGAAACACCAAAGAACTGCACGATTGTCCCTGCCTTTGGAAGGTCTCATTCCCTGTCATTCCTTCATTCAGTCAACAAACTTGGAGGACCCAGTATGTGCTACATTTTGAGGATAAAGTGATGAACAACACAGACAAGATCCCTGCCCTTGTGGAGTCTATATTCAAACCAGAGCTTGACCTTCAAACTGAGAGACCAACTTAAAAATGGGGCCATCTGGCCACTAACTGTTATACACCCTCTGCTTGGGACACACGGTCTCAGCCCTCCTCCACCTTCAAGTCTGATAGGAGAGAGATTTCAGAGTGGCCCAAACAATCTAAAGTAAAAGTGAACAGAGTTCAAAATAAGTCCTCAAGGGCTGAGGGGAGACCAAGGGGAAGATAATGCGGTGAGGGCACTGAGAGAGGGATTCCTAGAGGAATTGTACCTTGCTTTGAATTTTAGCCCTAAGCTGCAAATCCTAGCTAACTTCTAAGTAGATGCTGACAGCTGGCTTCTATTTGGTCTGCCATATTGAATGGCTTTGTCCCCAGGACATGGTGGAGATTTAGACAACCCAGGGCAGAAAATCCTCTAGGAAAGGAAGTCTGAACTACACCGCTGGCTTTCTGAAAGGACAGGATTTGAGGAGCTGGGATGGTAGTAGGGGAGAGGGCAGCTGGGTGGGGTTTCTTCCAGGAAACAATGTGGATGCAAGATGCAGTCCTCGTCCCTGGCCTGCCCTTACCGCTTTAGTATTTCAGATGAGTCAGCTCTCACTCTGCCACCTGCTTTCTGTAACTCTGCAGCAGGCCAGCAGCCTCCAGTCCACCCTCTCCTCCTCCCAGGGCTCTGGGGTGAAGCCCTCCCCAGGAACTCCCTGGCTCCCAGTACCCATGGGAGAAGCTCTTTTCAACTGACATGATTTATTTTAACAATAAGAGGAAAAAACCACATCCGATTTCCACAGAATTAGAGTTCCTCCTGACACGCCTGGACTTGCCAGTTGGGAAGGACACTCTCAAGCCATCCTCTATGCCATTTGCCGTTCTGCTGTTCCTTTGCTTGGAGGGAAGAGATGCCTGTTTCTATAGGGAGGAAGTTTGAAGTGAGAAGAGAGGACAAAGATTCTGTGAATGGAAAGAGCACTGGACTGAGAGTTCAGGGATGTGGCCTCCGGTCCCAGCTCCACCACTACTCAGTTGTCTGACGAAGGAAACAGAAAGTTGTGATACAATGTGGGTGACACATTGCCTAGAAAGAAGTGCCGTTGTGATACGCTTATGTTGGTGGGATGGGGGAAAGAAATAACAGGTTTGTATGGAGTGTTATGAAAGAATTAAATCTTAACCTTCCATTGGGGTAAGCTGATGGAAACAACCATAGCAAAGGACAGACTGAATATTTTTTTATTCTCTTTATAGAAAATAACAGTAAAAAAAAGTATTGACATAGGAGAAGGAAACAAAAAGTTGTCAGGAGTTAATGAATAGAAATATTATTTTTTTCTGGATTTTATGGTGTTTGTGTTATTTGTTAGCTTTTATGAATTTGTAATTTGTTGTAATTTCTTTCTAAATAAGTATTTACTTTTGTCTCTAATTTTGTCCATCTATTTTTGAATTCAATTTTCAAATTCAAAACGCTTCTCTCGGCCGGGCACGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGTCGAGGAGGGCGGATCACGAGGTCAGGAGATCGAGACCATCCTGGCTAACACAGTGAAACCCCGTCTCTACTAAAAATACAAAAAATTAGCCAGGCGAGGTGGTGGGCGCCTGTAGTCCCAGCTACTCGGGAGGCTGAGGCAGGAGAATGGCATGAACCCCGGGGGGCGGAGCCTGCAGTGAGCCGAGATCGTGCCACTGCACTCCAGCCTGGGTGACAGCGAGACTCCGTCTC"
+
+    # cigar = "1I1=8I1=6I3=2I2=2I2291=333D"
+
+    # new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2, 1000)
+
+    # print(len(seq1), len(seq2))
+    # print(len(new_seq1), len(new_seq2))

--- a/scripts/trim_indel_ends.py
+++ b/scripts/trim_indel_ends.py
@@ -20,8 +20,45 @@ from collections import defaultdict, Counter
 import re
 import edlib
 from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
+from Bio.Seq import Seq
 import matplotlib.pyplot as plt
 from tqdm import tqdm
+import os
+import sys
+import argparse
+import datetime
+
+#--------------------------------------------------------
+# parser
+#--------------------------------------------------------
+# positional/optional arguments
+posList = ['manifest','unique_isoform_aln']
+optList = ['mode', 'threshold']
+sys.stdout.write('\n'); sys.stdout.flush()
+
+# author and version info
+usage = sys.argv[0] + ' <options> ' + ' '.join(posList) + '\n'
+author = 'Author: Yutong Qiu (yutongq@andrew.cmu.edu)'
+version = 'Version: 1.0.0.0 (2022-11-23)'
+description = '\nDescription: This program trims isoform sequences to reduce false positives. Output trimmed sequences in trimmed.fasta'
+
+parser = argparse.ArgumentParser(usage = '\n'.join([usage, author, version, description]), formatter_class=argparse.RawTextHelpFormatter)
+# positional arguments
+parser.add_argument(posList[0], type=str, help='string\tinput manifest csv file in format: sample,fa.  e.g. /in/manifest.csv')
+parser.add_argument(posList[1], type=str, help='string\talignment between similar isoforms within each window.  e.g. /in/unique_isoforms_and_aln_stats.tsv')
+# optional arguments
+parser.add_argument('-m', '--'+optList[0], type=str, metavar='', default='lenient', help='string\tMode of trimming. "Strict" only trims when sequences match exactly after trimming; "Lenient" trims whenever prefix and suffix indel numbers below threshold, defauls to "Lenient"')
+parser.add_argument('-t', '--'+optList[1], type=int, metavar='', default=10000, help='int\tThreshold for trimming, defaults to 10000 (trim every prefix and suffix)')
+
+# strict positional/optional arguments checking
+argsDict = vars(parser.parse_args())
+sys.stdout.write('\n' + datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - ' + sys.argv[0] + ' - Parsing Input Arguements...\n\n'); sys.stdout.flush()
+for key, value in argsDict.items():
+    if key in posList: sys.stdout.write(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - Required Argument - ' + key +': '+ str(value) + '\n'); sys.stdout.flush()
+    if key in optList: sys.stdout.write(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - Optional Argument - ' + key +': '+ str(value) + '\n'); sys.stdout.flush()
+    vars()[key] = value # assign values of arguments into shorthand global variables
+sys.stdout.write('\n'); sys.stdout.flush()
 
 def extract_edits(cigar_str) -> list:
     """Given a cigar string, return separated edits with counts
@@ -70,7 +107,7 @@ def get_len_type(indel_list:list) -> tuple[str, str]:
             indel_length += edit[0]
     return indel_type, indel_length
 
-def get_prefix_and_suffix_indels(cigar_str:str) -> tuple:
+def get_prefix_and_suffix_indels(cigar_str:str, mode="lenient") -> tuple:
     """Get indel edits from the prefix and suffix of the cigar string
 
     Args:
@@ -82,14 +119,19 @@ def get_prefix_and_suffix_indels(cigar_str:str) -> tuple:
     all_edits = extract_edits(cigar_str)
     prefix_indels = []
     suffix_indels = []
+    i = 0
     for i in range(len(all_edits)):
         if all_edits[i][-1] != "I" and all_edits[i][-1] != "D":
             break
         prefix_indels.append(all_edits[i])
-    for i in range(len(all_edits)-1, -1, -1):
-        if all_edits[i][-1] != "I" and all_edits[i][-1] != "D":
+    j = len(all_edits)-1
+    for j in range(len(all_edits)-1, -1, -1):
+        if all_edits[j][-1] != "I" and all_edits[j][-1] != "D":
             break
-        suffix_indels.append(all_edits[i])
+        suffix_indels.append(all_edits[j])
+    for idx in range(i,j+1):
+        if all_edits[idx][-1] != "=" and mode == "strict":
+            return ("", 0), ("",0)
 
     # return prefix_indels, suffix_indels[::-1]
     return get_len_type(prefix_indels), get_len_type(suffix_indels[::-1])
@@ -124,7 +166,7 @@ def trim_seq(prefix_type, prefix_len, suffix_type, suffix_len, seq, num, thresho
             seq = seq[:-min(threshold, suffix_len)]
     return seq
 
-def trim_from_cigar(cigar_str, sequence1, sequence2, threshold=10):
+def trim_from_cigar(cigar_str, sequence1, sequence2, threshold=10, mode="lenient"):
     """Given two sequences and the cigar string describing the alignment between them, trim the start and end, if the 
     alignment starts and/or ends with indels.
 
@@ -133,12 +175,15 @@ def trim_from_cigar(cigar_str, sequence1, sequence2, threshold=10):
         sequence1(str): aligned sequence 1 to be trimmed
         sequence2(str): aligned sequence 2 to be trimmed
         threshold(int): maximum number of bases trimmed
+        mode(str): strict or lenient
+            - strict: only trim if the trimmed result will be all matches
+            - lenient: trim whenever there are indels at the edge of the strings
     Returns:
         str: trimmed sequence 1
         str: trimmed sequence 2
     """
 
-    (prefix_type, prefix_length), (suffix_type, suffix_length) = get_prefix_and_suffix_indels(cigar_str)
+    (prefix_type, prefix_length), (suffix_type, suffix_length) = get_prefix_and_suffix_indels(cigar_str, mode)
 
     if prefix_length == 0 and suffix_length == 0:
         return sequence1, sequence2
@@ -149,9 +194,9 @@ def trim_from_cigar(cigar_str, sequence1, sequence2, threshold=10):
     sequence1 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence1, 1, threshold)
     sequence2 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence2, 2, threshold)
 
-    global correct_trim
+    global effective_trim
     if len(sequence1) == len(sequence2) and sequence1 == sequence2:
-        correct_trim += 1
+        effective_trim += 1
 
     return sequence1, sequence2
 
@@ -168,31 +213,63 @@ def read_fasta(fname:str, sample_name:str, seq_dict:dict) -> dict:
         dict: dictionary matching read name to sequence
     """
     fasta_sequences = SeqIO.parse(open(fname),'fasta')
-    for fasta in tqdm(fasta_sequences):
+    count = 0
+    for fasta in fasta_sequences:
         name, sequence = fasta.id, str(fasta.seq)
         seq_dict[sample_name + "_" + name] = sequence
+        count += 1
+    print("Read %i sequences in sample %s" % (count, sample_name))
     return seq_dict
 
+# total number of pairs of sequences getting trimmed
 total_trim = 0
-correct_trim = 0
 
-def main():
-    input_dir_aln = "/Users/yutongq/SVHackathon2022/isocomp/data/"
-    input_dir_fasta = "/Users/yutongq/SVHackathon2022/"
+# total number of pairs of sequences that are identical after getting trimmed
+effective_trim = 0
 
-    aln_fname = input_dir_aln+"unique_isoforms_and_aln_stats.tsv"
-    fasta_1_fname = input_dir_fasta+"HG002_MM2_corrected.fasta"
-    fasta_2_fname = input_dir_fasta+"HG004_MM2_corrected.fasta"
-    fasta_3_fname = input_dir_fasta+"HG005_MM2_corrected.fasta"
+def parseManifest(manifest:str) -> dict:
+    """Parse Manifest file
+
+    Args:
+        manifest (str): manifest in format sample,fa_path
+
+    Returns:
+        dict: read_sequence: {read_id: sequence}
+    """
+    print("Parsing fasta files...")
+
+    # read manifest
+    with open(manifest) as f: fields = [ l.strip().split(',') for l in f ]
 
     read_sequence = dict()
 
-    print("Parsing fasta files...")
-    read_sequence = read_fasta(fasta_1_fname, "HG002", read_sequence)
-    read_sequence = read_fasta(fasta_2_fname, "HG004", read_sequence)
-    read_sequence = read_fasta(fasta_3_fname, "HG005", read_sequence)
+    for sample,fa in fields:
+        read_sequence = read_fasta(fa, sample, read_sequence)
+    return read_sequence
 
-    aln_stats_df = pd.read_csv(aln_fname, sep="\t").dropna()
+def write_fasta(processed_read, read_sequence, mode, threshold):
+    records = defaultdict(list)
+    for read_id in read_sequence:
+        sample_name = read_id.split("_")[0]
+        sequence = read_sequence[read_id]
+        if read_id in processed_read:
+            sequence = processed_read[read_id]
+            if sequence == "":
+                sequence = read_sequence[read_id]
+
+        record = SeqRecord( Seq(sequence), id=read_id, description="" )
+        records[sample_name].append(record)
+
+    for sample_name in records:
+        with open("%s_trimmed_%s_%s.fasta" % (sample_name, mode, str(threshold)), "w") as out:
+            SeqIO.write(records[sample_name], out, "fasta")
+        print("%i sequences in %s" % (len(records[sample_name]), sample_name))
+        print("Trimmed written to %s_trimmed_%s_%s.fasta" % (sample_name, mode, str(threshold)))
+
+def main(manifest, unique_isoform_aln, mode, threshold):
+
+    read_sequence = parseManifest(manifest)
+    aln_stats_df = pd.read_csv(unique_isoform_aln, sep="\t")
     aln_records = aln_stats_df.to_dict("records")
 
     unique_read_pairs = defaultdict()
@@ -202,27 +279,47 @@ def main():
     print("Parsing read comparisons...")
     for record in tqdm(aln_records):
         read_id = record["sample_from"] + "_" + record["isoform_name"]
-        selected_alignments = record["selected_alignments"].split(",")
+
+        unique_read_pairs[read_id] = ""
+
+        try:
+            selected_alignments = record["selected_alignments"].split(",")
+        except:
+            continue
         for alignment in selected_alignments:
             compared_to= alignment.split("__")[1]
 
-            # # store a pair only once
-            if compared_to in unique_read_pairs_ed and read_id in unique_read_pairs_ed[compared_to]:
-                continue
+            # # # store a pair only once
+            # if compared_to in unique_read_pairs_ed and read_id in unique_read_pairs_ed[compared_to]:
+            #     continue
 
-            cigar = alignment.split("_")[-1]
+            cigar = alignment.split("__")[-1]
 
             read_pair_cigar[read_id][compared_to] = cigar
-            ed = edlib.align(read_sequence[read_id], read_sequence[compared_to])["editDistance"]
+
+            align = edlib.align(read_sequence[compared_to], read_sequence[read_id],mode="NW", task="path")
+            ed = align["editDistance"]
+            cigar_rev = align["cigar"]
+
+            read_pair_cigar[compared_to][read_id] = cigar_rev
+
             unique_read_pairs_ed[read_id][compared_to] = ed
+            unique_read_pairs_ed[compared_to][read_id] = ed
 
             # if a read is matched with multiple reads, keep only the most similar pair
-            if read_id in unique_read_pairs:
+            if read_id in unique_read_pairs and unique_read_pairs[read_id] != "":
                 opt_compared_to = unique_read_pairs[read_id]
                 if ed < unique_read_pairs_ed[read_id][opt_compared_to]:
                     unique_read_pairs[read_id] = compared_to
             else:
                 unique_read_pairs[read_id] = compared_to
+
+            if compared_to in unique_read_pairs and unique_read_pairs[compared_to] != "":
+                opt_read_id = unique_read_pairs[compared_to]
+                if ed < unique_read_pairs_ed[compared_to][opt_read_id]:
+                    unique_read_pairs[compared_to] = read_id
+            else:
+                unique_read_pairs[compared_to] = read_id
 
     print("Trimming...")
 
@@ -231,18 +328,30 @@ def main():
     length_diff1 = []
     length_diff2 = []
 
-    processed_read = set()
+    processed_read = dict()
     for read_id in tqdm(unique_read_pairs):
+
         compared_to = unique_read_pairs[read_id]
+
+        processed_read[read_id] = ""
+
+        if compared_to == "":
+            processed_read[read_id] = read_sequence[read_id]
+            continue
+
+        if compared_to in processed_read and read_id in processed_read:
+            continue
+
+        processed_read[compared_to] = ""
+
         cigar = read_pair_cigar[read_id][compared_to]
 
         seq1 = read_sequence[read_id]
         seq2 = read_sequence[compared_to]
-        new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2, threshold=100000)
+        new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2, threshold=threshold, mode=mode)
         old_ed = ed_from_cigar(read_pair_cigar[read_id][compared_to])
         new_align = edlib.align(new_seq1, new_seq2,mode = "NW", task = "path" )
         new_ed = new_align['editDistance']
-        new_cigar = new_align["cigar"]
 
         if seq1 != new_seq1 or seq2 != new_seq2:
             old_eds.append(old_ed)
@@ -253,46 +362,42 @@ def main():
             else:
                 length_diff2.append(abs(len(seq1) - len(new_seq1)))
                 length_diff2.append(abs(len(seq2) - len(new_seq2)))
-        processed_read.add(read_id)
-        processed_read.add(compared_to)
 
+            # retain the longer sequence
+            
+            if len(new_seq1) >= len(processed_read[read_id]):
+                processed_read[read_id] = new_seq1
+            if len(new_seq2) >= len(processed_read[compared_to]):
+                processed_read[compared_to] = new_seq2
     
-    # for read_id in read_sequence:
-    #     if read_id not in processed_read:
-    #         print(read_id)
-
-        # print("Length:", len(seq1), len(seq2), len(new_seq1), len(new_seq2))
+    write_fasta(processed_read, read_sequence, mode, threshold)
 
     print("Total reads:", len(read_sequence))
     print("Total pairs:", len(unique_read_pairs))
     print("Total trim:", total_trim)
-    print("Correct trim:", correct_trim)
+    print("Correct trim:", effective_trim)
 
     fig, ax = plt.subplots(1)
     ax.scatter(old_eds, new_eds, s=5)
     ax.plot([0, max(old_eds)], [0, max(old_eds)], color="red")
+    ax.set_xrange(0, 20)
     ax.set_xlabel("original edit distance")
     ax.set_ylabel("timmed edit distance")
     ax.set_title("Edit distance before and after trimming")
-    fig.savefig("ED_trim.png")
+    fig.savefig("ED_trim_%s_%s.png" % (mode, str(threshold)))
+    print("Scatterplot saved to ED_trim_%s_%s.png" % (mode, str(threshold)))
 
 
     fig,ax = plt.subplots(1)
-    ax.hist(length_diff1, range=[0,100],bins=100)
-    ax.hist(length_diff2, range=[0,100],bins=100, alpha=0.5)
+    ax.hist(length_diff1, range=[0,100],bins=100,label="ed=0")
+    ax.hist(length_diff2, range=[0,100],bins=100, alpha=0.5, label="ed!=0")
+    ax.set_title("Distribution of trimmed lengths")
+    ax.set_xlabel("Number of bases")
+    ax.set_ylabel("Number of sequences")
+    ax.legend()
 
-    fig.savefig("ED_trim_length.png")
+    fig.savefig("ED_trim_length_%s_%s.png" % (mode, str(threshold)))
+    print("Histogram saved to ED_trim_length_%s_%s.png" % (mode, str(threshold)))
 
 if __name__ == "__main__":
-    main()
-
-    # seq1="GTCTTTCCTCATTTACAGCTAGCTCTGCCAGTCTGTGTCTTTGCTGTGTCTGTGGATGTGAGTGTCCCTGCTGGTCTGTAGGAGATGGTATTTTGGGGGCAGCTGCAAGGGAAAAAACTGATCTGCTACTTACACAGCGCCGTAGCCTCAGCCTGAGGGTCTTCAGGTTCTCCCCCAGGGAGTTCACATGCGCCTTGATGTCTGGGTCTTGGTTCTCAGCTTGGGGCATCACCTCCTCCAGGTAAAACTGGATCATCTCAGACAAGGCTTGGCAACCCAGGTAACCCTAAGGGCAGGAGCCAAAGAGCGGTGCTTGCACACACTGACAGGAGTCCAAGAATGTGCACTGAGGGAGCGTTTCCGCACAGATCTGCGTGTTCCTTACCACTCACACATGTGCACACACATATCCATGTGTGTGTGCCAGTGCTTTGGGGCTCTGTTCCACGGGGTGCAAACCCTAGACGAAAAAAGACTGTAATTCAACTCTTCAGTAGCCAGGATTGCCTGTCTCCAACCCCTTCTGAATCTAGTTATGTTGGATACTGGGAGAGAAGCATGTAGACTCTTTGGGCCTGACCTTTCTGATTTTTCTCTGGAAGGGCTTCACTGAAGGGGCACAGAAGAATAATGTTTCTACAGCATAGATCCAGGGGCTCCTCCCCACCAGGAACCCAGCTTAGCAGGCAGGCTGTTCATGTGGAACTCGCCAAAACCCCGTGCAGGTGGATGTGCGGAAACACCAAAGAACTGCACGATTGTCCCTGCCTTTGGAAGGTCTCATTCCCTGTCATTCCTTCATTCAGTCAACAAACTTGGAGGACCCAGTATGTGCTACATTTTGAGGATAAAGTGATGAACAACACAGACAAGATCCCTGCCCTTGTGGAGTCTATATTCAAACCAGAGCTTGACCTTCAAACTGAGAGACCAACTTAAAAATGGGGCCATCTGGCCACTAACTGTTATACACCCTCTGCTTGGGACACACGGTCTCAGCCCTCCTCCACCTTCAAGTCTGATAGGAGAGAGATTTCAGAGTGGCCCAAACAATCTAAAGTAAAAGTGAACAGAGTTCAAAATAAGTCCTCAAGGGCTGAGGGGAGACCAAGGGGAAGATAATGCGGTGAGGGCACTGAGAGAGGGATTCCTAGAGGAATTGTACCTTGCTTTGAATTTTAGCCCTAAGCTGCAAATCCTAGCTAACTTCTAAGTAGATGCTGACAGCTGGCTTCTATTTGGTCTGCCATATTGAATGGCTTTGTCCCCAGGACATGGTGGAGATTTAGACAACCCAGGGCAGAAAATCCTCTAGGAAAGGAAGTCTGAACTACACCGCTGGCTTTCTGAAAGGACAGGATTTGAGGAGCTGGGATGGTAGTAGGGGAGAGGGCAGCTGGGTGGGGTTTCTTCCAGGAAACAATGTGGATGCAAGATGCAGTCCTCGTCCCTGGCCTGCCCTTACCGCTTTAGTATTTCAGATGAGTCAGCTCTCACTCTGCCACCTGCTTTCTGTAACTCTGCAGCAGGCCAGCAGCCTCCAGTCCACCCTCTCCTCCTCCCAGGGCTCTGGGGTGAAGCCCTCCCCAGGAACTCCCTGGCTCCCAGTACCCATGGGAGAAGCTCTTTTCAACTGACATGATTTATTTTAACAATAAGAGGAAAAAACCACATCCGATTTCCACAGAATTAGAGTTCCTCCTGACACGCCTGGACTTGCCAGTTGGGAAGGACACTCTCAAGCCATCCTCTATGCCATTTGCCGTTCTGCTGTTCCTTTGCTTGGAGGGAAGAGATGCCTGTTTCTATAGGGAGGAAGTTTGAAGTGAGAAGAGAGGACAAAGATTCTGTGAATGGAAAGAGCACTGGACTGAGAGTTCAGGGATGTGGCCTCCGGTCCCAGCTCCACCACTACTCAGTTGTCTGACGAAGGAAACAGAAAGTTGTGATACAATGTGGGTGACACATTGCCTAGAAAGAAGTGCCGTTGTGATACGCTTATGTTGGTGGGATGGGGGAAAGAAATAACAGGTTTGTATGGAGTGTTATGAAAGAATTAAATCTTAACCTTCCATTGGGGTAAGCTGATGGAAACAACCATAGCAAAGGACAGACTGAATATTTTTTTATTCTCTTTATAGAAAATAACAGTAAAAAAAAGTATTGACATAGGAGAAGGAAACAAAAAGTTGTCAGGAGTTAATGAATAGAAATATTATTTTTTTCTGGATTTTATGGTGTTTGTGTTATTTGTTAGCTTTTATGAATTTGTAATTTGTTGTAATTTCTTTCTAAATAAGTATTTACTTTTGTCTCT"
-
-    # seq2 = "TAGCTCTGCCAGTCTGTGTCTTTGCTGTGTCTGTGGATGTGAGTGTCCCTGCTGGTCTGTAGGAGATGGTATTTTGGGGGCAGCTGCAAGGGAAAAAACTGATCTGCTACTTACACAGCGCCGTAGCCTCAGCCTGAGGGTCTTCAGGTTCTCCCCCAGGGAGTTCACATGCGCCTTGATGTCTGGGTCTTGGTTCTCAGCTTGGGGCATCACCTCCTCCAGGTAAAACTGGATCATCTCAGACAAGGCTTGGCAACCCAGGTAACCCTAAGGGCAGGAGCCAAAGAGCGGTGCTTGCACACACTGACAGGAGTCCAAGAATGTGCACTGAGGGAGCGTTTCCGCACAGATCTGCGTGTTCCTTACCACTCACACATGTGCACACACATATCCATGTGTGTGTGCCAGTGCTTTGGGGCTCTGTTCCACGGGGTGCAAACCCTAGACGAAAAAAGACTGTAATTCAACTCTTCAGTAGCCAGGATTGCCTGTCTCCAACCCCTTCTGAATCTAGTTATGTTGGATACTGGGAGAGAAGCATGTAGACTCTTTGGGCCTGACCTTTCTGATTTTTCTCTGGAAGGGCTTCACTGAAGGGGCACAGAAGAATAATGTTTCTACAGCATAGATCCAGGGGCTCCTCCCCACCAGGAACCCAGCTTAGCAGGCAGGCTGTTCATGTGGAACTCGCCAAAACCCCGTGCAGGTGGATGTGCGGAAACACCAAAGAACTGCACGATTGTCCCTGCCTTTGGAAGGTCTCATTCCCTGTCATTCCTTCATTCAGTCAACAAACTTGGAGGACCCAGTATGTGCTACATTTTGAGGATAAAGTGATGAACAACACAGACAAGATCCCTGCCCTTGTGGAGTCTATATTCAAACCAGAGCTTGACCTTCAAACTGAGAGACCAACTTAAAAATGGGGCCATCTGGCCACTAACTGTTATACACCCTCTGCTTGGGACACACGGTCTCAGCCCTCCTCCACCTTCAAGTCTGATAGGAGAGAGATTTCAGAGTGGCCCAAACAATCTAAAGTAAAAGTGAACAGAGTTCAAAATAAGTCCTCAAGGGCTGAGGGGAGACCAAGGGGAAGATAATGCGGTGAGGGCACTGAGAGAGGGATTCCTAGAGGAATTGTACCTTGCTTTGAATTTTAGCCCTAAGCTGCAAATCCTAGCTAACTTCTAAGTAGATGCTGACAGCTGGCTTCTATTTGGTCTGCCATATTGAATGGCTTTGTCCCCAGGACATGGTGGAGATTTAGACAACCCAGGGCAGAAAATCCTCTAGGAAAGGAAGTCTGAACTACACCGCTGGCTTTCTGAAAGGACAGGATTTGAGGAGCTGGGATGGTAGTAGGGGAGAGGGCAGCTGGGTGGGGTTTCTTCCAGGAAACAATGTGGATGCAAGATGCAGTCCTCGTCCCTGGCCTGCCCTTACCGCTTTAGTATTTCAGATGAGTCAGCTCTCACTCTGCCACCTGCTTTCTGTAACTCTGCAGCAGGCCAGCAGCCTCCAGTCCACCCTCTCCTCCTCCCAGGGCTCTGGGGTGAAGCCCTCCCCAGGAACTCCCTGGCTCCCAGTACCCATGGGAGAAGCTCTTTTCAACTGACATGATTTATTTTAACAATAAGAGGAAAAAACCACATCCGATTTCCACAGAATTAGAGTTCCTCCTGACACGCCTGGACTTGCCAGTTGGGAAGGACACTCTCAAGCCATCCTCTATGCCATTTGCCGTTCTGCTGTTCCTTTGCTTGGAGGGAAGAGATGCCTGTTTCTATAGGGAGGAAGTTTGAAGTGAGAAGAGAGGACAAAGATTCTGTGAATGGAAAGAGCACTGGACTGAGAGTTCAGGGATGTGGCCTCCGGTCCCAGCTCCACCACTACTCAGTTGTCTGACGAAGGAAACAGAAAGTTGTGATACAATGTGGGTGACACATTGCCTAGAAAGAAGTGCCGTTGTGATACGCTTATGTTGGTGGGATGGGGGAAAGAAATAACAGGTTTGTATGGAGTGTTATGAAAGAATTAAATCTTAACCTTCCATTGGGGTAAGCTGATGGAAACAACCATAGCAAAGGACAGACTGAATATTTTTTTATTCTCTTTATAGAAAATAACAGTAAAAAAAAGTATTGACATAGGAGAAGGAAACAAAAAGTTGTCAGGAGTTAATGAATAGAAATATTATTTTTTTCTGGATTTTATGGTGTTTGTGTTATTTGTTAGCTTTTATGAATTTGTAATTTGTTGTAATTTCTTTCTAAATAAGTATTTACTTTTGTCTCTAATTTTGTCCATCTATTTTTGAATTCAATTTTCAAATTCAAAACGCTTCTCTCGGCCGGGCACGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGTCGAGGAGGGCGGATCACGAGGTCAGGAGATCGAGACCATCCTGGCTAACACAGTGAAACCCCGTCTCTACTAAAAATACAAAAAATTAGCCAGGCGAGGTGGTGGGCGCCTGTAGTCCCAGCTACTCGGGAGGCTGAGGCAGGAGAATGGCATGAACCCCGGGGGGCGGAGCCTGCAGTGAGCCGAGATCGTGCCACTGCACTCCAGCCTGGGTGACAGCGAGACTCCGTCTC"
-
-    # cigar = "1I1=8I1=6I3=2I2=2I2291=333D"
-
-    # new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2, 1000)
-
-    # print(len(seq1), len(seq2))
-    # print(len(new_seq1), len(new_seq2))
+    main(manifest, unique_isoform_aln, mode, threshold)

--- a/scripts/trim_indel_ends.py
+++ b/scripts/trim_indel_ends.py
@@ -28,6 +28,13 @@ import os
 import sys
 import argparse
 import datetime
+import logging
+
+logging.basicConfig()
+logging.root.setLevel(logging.CRITICAL)
+
+logging_handle = "trim_indel_ends"
+logger = logging.getLogger(logging_handle)
 
 #--------------------------------------------------------
 # parser
@@ -35,7 +42,7 @@ import datetime
 # positional/optional arguments
 posList = ['manifest','unique_isoform_aln']
 optList = ['mode', 'threshold']
-sys.stdout.write('\n'); sys.stdout.flush()
+print()
 
 # author and version info
 usage = sys.argv[0] + ' <options> ' + ' '.join(posList) + '\n'
@@ -53,53 +60,82 @@ parser.add_argument('-t', '--'+optList[1], type=int, metavar='', default=10000, 
 
 # strict positional/optional arguments checking
 argsDict = vars(parser.parse_args())
-sys.stdout.write('\n' + datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - ' + sys.argv[0] + ' - Parsing Input Arguements...\n\n'); sys.stdout.flush()
+logger.critical('\n' + datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - ' + sys.argv[0] + ' - Parsing Input Arguements...\n\n')
 for key, value in argsDict.items():
-    if key in posList: sys.stdout.write(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - Required Argument - ' + key +': '+ str(value) + '\n'); sys.stdout.flush()
-    if key in optList: sys.stdout.write(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - Optional Argument - ' + key +': '+ str(value) + '\n'); sys.stdout.flush()
+    if key in posList: logger.critical(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - Required Argument - ' + key +': '+ str(value) + '\n')
+    if key in optList: logger.critical(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S') + ' - Optional Argument - ' + key +': '+ str(value) + '\n')
     vars()[key] = value # assign values of arguments into shorthand global variables
-sys.stdout.write('\n'); sys.stdout.flush()
+logger.critical('\n')
 
-def extract_edits(cigar_str) -> list:
-    """Given a cigar string, return separated edits with counts
+class TrimTracker:
+    """
+    Class for tracking the number of trims done
+
+    Member variables:
+        total_trim (int) --- total number of trimming performed
+        effective_trim (int) --- number of trims that result in equality between strings
+    """
+    def __init__(self):
+        self.total_trim = 0
+        self.effective_trim = 0
+
+def extract_edits(cigar_str:str):
+    """  Given a cigar string, return separated edits with counts
 
     Args:
-        cigar_str (str):
+        cigar_str (str): Input cigar string
 
     Returns:
-        list: a list of tuples of (count, edit_type)
+        all_edits (list): a list of tuples of (count, edit_type)
+
+    Example:
+        Input: 10=5I2D3X
+        Output: [(10, '='), (5, 'I'), (2, 'D'), (3, 'X')]
     """
+
     all_edits = [(int(s[:-1]), s[-1]) for s in re.findall(r'\d+[=,I,D,X]', cigar_str)]
     return all_edits
 
-def ed_from_cigar(cigar_str) -> int:
+def ed_from_cigar(cigar_str: str) -> int:
+
     """Compute edit distance from cigar strings
 
     Args:
         cigar_str (str): cigar string
 
     Returns:
-        int: edit distance that is equal to total length of the string minus the nu
+        edit_distance (int): edit distance that is equal to total length of the string minus the number of matched characters
+
+    Example: 
+        Input:10=5I2D3X
+        Output: 10 (total length = 20, total matched = 10)
     """
+    
     all_edits = extract_edits(cigar_str)
     total_length = sum([e[0] for e in all_edits])
     match_count = sum([e[0] for e in all_edits if e[1] == "="])
     return total_length - match_count
 
 def get_len_type(indel_list:list) -> tuple[str, str]:
-    """Given a list of indels, return the total length and type
+    """Given a list of indels, return the total length and type. This function concatenates indels of the same type. Just in case.
 
     Args:
         indel_list (list): list of indels
 
     Returns:
         tuple[str, str]: type, length
+
+    Example:
+        Input: 3D2D
+        Output: "D",5
     """
 
     indel_type = ""
     indel_length = 0
     if len(indel_list) != 0:
         for edit in indel_list:
+
+            # make sure that all indels are of the same type
             if indel_type != "":
                 assert indel_type == edit[-1]
             else:
@@ -115,23 +151,38 @@ def get_prefix_and_suffix_indels(cigar_str:str, mode="lenient") -> tuple:
 
     Returns:
         tuple: (list, list): prefix list of indels and suffix list of indels
+
+    Example:
+        Input1: 5D3X2=1I, "lenient"
+        Output1: ("D", 5), ("I", 1)
+
+        Input2: 5D3X2=1I, "strict"
+        Output2: ("", 0), ("", 0)
     """
     all_edits = extract_edits(cigar_str)
     prefix_indels = []
     suffix_indels = []
     i = 0
+    # investigate prefix of the cigar string
     for i in range(len(all_edits)):
+        # break out of the loop if the current edit is no longer an INDEL
         if all_edits[i][-1] != "I" and all_edits[i][-1] != "D":
             break
         prefix_indels.append(all_edits[i])
+
+    # investigate suffix of the cigar string
     j = len(all_edits)-1
     for j in range(len(all_edits)-1, -1, -1):
+        # break out of the loop if the current edit is no longer an INDEL
         if all_edits[j][-1] != "I" and all_edits[j][-1] != "D":
             break
         suffix_indels.append(all_edits[j])
-    for idx in range(i,j+1):
-        if all_edits[idx][-1] != "=" and mode == "strict":
-            return ("", 0), ("",0)
+
+    # under strict mode, do not trim if the sequences were not matched exactly
+    if mode == "strict":
+        for idx in range(i,j+1):
+            if all_edits[idx][-1] != "=":
+                return ("", 0), ("",0)
 
     # return prefix_indels, suffix_indels[::-1]
     return get_len_type(prefix_indels), get_len_type(suffix_indels[::-1])
@@ -145,12 +196,20 @@ def trim_seq(prefix_type, prefix_len, suffix_type, suffix_len, seq, num, thresho
         suffix_type (str):type of edits at the end of the cigar, ("I" or "D")
         suffix_len (int): length of suffix edits
         seq (str): input sequence to be trimmed
-        num (int): ranking of the sequence. If a sequence is the first in alignment, deletion means that removing. 
+        num (int): The order of the sequence in alignment. If a sequence is the first in alignment, deletion means that a character is removed. 
         Otherwise, insertion means trimming.
         threshold (int): maximum number of bases trimmed
 
     Returns:
         str: trimmed sequence
+
+    Example:
+        Input1: trim_seq("D", 1, "I",2, "ATCGAAG", 1)
+        Output1: "TCGAAG"  (The first character is trimmed but the suffix is not trimmed)
+        
+        Input2: trim_seq("D", 1, "I",2, "ATCGAAG", 2)
+        Output2: "ATCGA"  (The suffix of length 2 is trimmed but the prefix is not trimmed)
+
     """
     assert num == 1 or num == 2, "trim_seq(): unknown ranking of input sequence!"
 
@@ -166,7 +225,7 @@ def trim_seq(prefix_type, prefix_len, suffix_type, suffix_len, seq, num, thresho
             seq = seq[:-min(threshold, suffix_len)]
     return seq
 
-def trim_from_cigar(cigar_str, sequence1, sequence2, threshold=10, mode="lenient"):
+def trim_from_cigar(cigar_str, sequence1, sequence2, threshold=10, mode="lenient", trim_tracker=None):
     """Given two sequences and the cigar string describing the alignment between them, trim the start and end, if the 
     alignment starts and/or ends with indels.
 
@@ -188,15 +247,14 @@ def trim_from_cigar(cigar_str, sequence1, sequence2, threshold=10, mode="lenient
     if prefix_length == 0 and suffix_length == 0:
         return sequence1, sequence2
 
-    global total_trim
-    total_trim += 1
+    if trim_tracker != None:
+        trim_tracker.total_trim += 1
 
     sequence1 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence1, 1, threshold)
     sequence2 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence2, 2, threshold)
 
-    global effective_trim
-    if len(sequence1) == len(sequence2) and sequence1 == sequence2:
-        effective_trim += 1
+    if trim_tracker != None and len(sequence1) == len(sequence2) and sequence1 == sequence2:
+        trim_tracker.effective_trim += 1
 
     return sequence1, sequence2
 
@@ -218,14 +276,8 @@ def read_fasta(fname:str, sample_name:str, seq_dict:dict) -> dict:
         name, sequence = fasta.id, str(fasta.seq)
         seq_dict[sample_name + "_" + name] = sequence
         count += 1
-    print("Read %i sequences in sample %s" % (count, sample_name))
+    logger.critical("Read %i sequences in sample %s" % (count, sample_name))
     return seq_dict
-
-# total number of pairs of sequences getting trimmed
-total_trim = 0
-
-# total number of pairs of sequences that are identical after getting trimmed
-effective_trim = 0
 
 def parseManifest(manifest:str) -> dict:
     """Parse Manifest file
@@ -236,7 +288,7 @@ def parseManifest(manifest:str) -> dict:
     Returns:
         dict: read_sequence: {read_id: sequence}
     """
-    print("Parsing fasta files...")
+    logger.critical("Parsing fasta files...")
 
     # read manifest
     with open(manifest) as f: fields = [ l.strip().split(',') for l in f ]
@@ -247,7 +299,15 @@ def parseManifest(manifest:str) -> dict:
         read_sequence = read_fasta(fa, sample, read_sequence)
     return read_sequence
 
-def write_fasta(processed_read, read_sequence, mode, threshold):
+def write_fasta(processed_read: dict, read_sequence: dict, mode: str, threshold: int):
+    """Writes the processed reads into a fasta file into sample_name_trimmed_mode_threshold.fasta for each sample in read_sequence
+
+    Args:
+        processed_read (dict): a dictionary of trimmed reads accessible by read name
+        read_sequence (dict): a dictionary of original reads accessible by read name
+        mode (str): lenient or strict
+        threshold (int): threshold for trimming
+    """
     records = defaultdict(list)
     for read_id in read_sequence:
         sample_name = read_id.split("_")[0]
@@ -263,8 +323,8 @@ def write_fasta(processed_read, read_sequence, mode, threshold):
     for sample_name in records:
         with open("%s_trimmed_%s_%s.fasta" % (sample_name, mode, str(threshold)), "w") as out:
             SeqIO.write(records[sample_name], out, "fasta")
-        print("%i sequences in %s" % (len(records[sample_name]), sample_name))
-        print("Trimmed written to %s_trimmed_%s_%s.fasta" % (sample_name, mode, str(threshold)))
+        logger.critical("%i sequences in %s" % (len(records[sample_name]), sample_name))
+        logger.critical("Trimmed written to %s_trimmed_%s_%s.fasta" % (sample_name, mode, str(threshold)))
 
 def main(manifest, unique_isoform_aln, mode, threshold):
 
@@ -276,7 +336,9 @@ def main(manifest, unique_isoform_aln, mode, threshold):
     unique_read_pairs_ed = defaultdict(dict)          # {read_id1: {read_id2: edit distance}}
     read_pair_cigar = defaultdict(dict)               # {read_id1: {read_id2: cigar_string}}
 
-    print("Parsing read comparisons...")
+    trim_tracker = TrimTracker()
+
+    logger.critical("Parsing read comparisons...")
     for record in tqdm(aln_records):
         read_id = record["sample_from"] + "_" + record["isoform_name"]
 
@@ -321,7 +383,7 @@ def main(manifest, unique_isoform_aln, mode, threshold):
             else:
                 unique_read_pairs[compared_to] = read_id
 
-    print("Trimming...")
+    logger.critical("Trimming...")
 
     old_eds = []
     new_eds = []
@@ -348,7 +410,7 @@ def main(manifest, unique_isoform_aln, mode, threshold):
 
         seq1 = read_sequence[read_id]
         seq2 = read_sequence[compared_to]
-        new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2, threshold=threshold, mode=mode)
+        new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2, threshold=threshold, mode=mode, trim_tracker=trim_tracker)
         old_ed = ed_from_cigar(read_pair_cigar[read_id][compared_to])
         new_align = edlib.align(new_seq1, new_seq2,mode = "NW", task = "path" )
         new_ed = new_align['editDistance']
@@ -372,10 +434,10 @@ def main(manifest, unique_isoform_aln, mode, threshold):
     
     write_fasta(processed_read, read_sequence, mode, threshold)
 
-    print("Total reads:", len(read_sequence))
-    print("Total pairs:", len(unique_read_pairs))
-    print("Total trim:", total_trim)
-    print("Correct trim:", effective_trim)
+    logger.critical("Total reads: %i" % len(read_sequence))
+    logger.critical("Total pairs: %i" % len(unique_read_pairs))
+    logger.critical("Total trim: %i" % trim_tracker.total_trim)
+    logger.critical("Trims that result in equality: %i" % trim_tracker.effective_trim)
 
     fig, ax = plt.subplots(1)
     ax.scatter(old_eds, new_eds, s=5)
@@ -384,7 +446,7 @@ def main(manifest, unique_isoform_aln, mode, threshold):
     ax.set_ylabel("timmed edit distance")
     ax.set_title("Edit distance before and after trimming")
     fig.savefig("ED_trim_scatter_%s_%s.png" % (mode, str(threshold)))
-    print("Scatterplot saved to ED_trim_%s_%s.png" % (mode, str(threshold)))
+    logger.critical("Scatterplot saved to ED_trim_%s_%s.png" % (mode, str(threshold)))
 
 
     fig,ax = plt.subplots(1)
@@ -396,7 +458,7 @@ def main(manifest, unique_isoform_aln, mode, threshold):
     ax.legend()
 
     fig.savefig("ED_trim_length_distribution_%s_%s.png" % (mode, str(threshold)))
-    print("Histogram saved to ED_trim_length_%s_%s.png" % (mode, str(threshold)))
+    logger.critical("Histogram saved to ED_trim_length_%s_%s.png" % (mode, str(threshold)))
 
 if __name__ == "__main__":
     main(manifest, unique_isoform_aln, mode, threshold)

--- a/scripts/trim_indel_ends.py
+++ b/scripts/trim_indel_ends.py
@@ -1,0 +1,222 @@
+"""
+    File name: trim_indel_ends.py
+    Author: Yutong Qiu
+    Date: Nov 20
+    Description: For each pair of alinment between reads, if the best alignment includes indels at the beginning and ends
+        of the reads, then trim off the indels.
+    Output: new set of reads for each sample.
+"""
+
+import pandas as pd
+from collections import defaultdict, Counter
+import re
+
+def extract_edits(cigar_str) -> list:
+    """Given a cigar string, return separated edits with counts
+
+    Args:
+        cigar_str (str):
+
+    Returns:
+        list: a list of tuples of (count, edit_type)
+    """
+    all_edits = [(int(s[:-1]), s[-1]) for s in re.findall(r'\d+[=,I,D,X]', cigar_str)]
+    return all_edits
+
+def ed_from_cigar(cigar_str) -> int:
+    """Compute edit distance from cigar strings
+
+    Args:
+        cigar_str (str): cigar string
+
+    Returns:
+        int: edit distance that is equal to total length of the string minus the nu
+    """
+    all_edits = extract_edits(cigar_str)
+    total_length = sum([e[0] for e in all_edits])
+    match_count = sum([e[0] for e in all_edits if e[1] == "="])
+    return total_length - match_count
+
+def get_prefix_and_suffix_indels(cigar_str:str) -> tuple:
+    all_edits = extract_edits(cigar_str)
+    prefix_indels = []
+    suffix_indels = []
+    for i in range(len(all_edits)):
+        if all_edits[i][-1] != "I" and all_edits[i][-1] != "D":
+            break
+        prefix_indels.append(all_edits[i])
+    for i in range(len(all_edits)-1, -1, -1):
+        if all_edits[i][-1] != "I" and all_edits[i][-1] != "D":
+            break
+        suffix_indels.append(all_edits[i])
+    return prefix_indels, suffix_indels
+
+def trim_seq(prefix_type, prefix_len, suffix_type, suffix_len, seq, num) -> str:
+    """Trim input sequence according to suffix and prefix number of indels
+
+    Args:
+        prefix_type (str): type of edits at the beginning of the cigar, ("I" or "D")
+        prefix_len (int): length of prefix edits
+        suffix_type (str):type of edits at the end of the cigar, ("I" or "D")
+        suffix_len (int): length of suffix edits
+        seq (str): input sequence to be trimmed
+        num (int): ranking of the sequence. If a sequence is the first in alignment, deletion means that removing. 
+        Otherwise, insertion means trimming.
+
+    Returns:
+        str: trimmed sequence
+    """
+    assert num == 1 or num == 2, "trim_seq(): unknown ranking of input sequence!"
+
+    if num == 1:
+        if prefix_type == "D":
+            seq = seq[prefix_len:]
+        if suffix_type == "D":
+            seq = seq[:-suffix_len]
+    if num == 1:
+        if prefix_type == "I":
+            seq = seq[prefix_len:]
+        if suffix_type == "I":
+            seq = seq[:-suffix_len]
+    return seq
+
+def trim_from_cigar(cigar_str, sequence1, sequence2):
+    """Given two sequences and the cigar string describing the alignment between them, trim the start and end, if the 
+    alignment starts and/or ends with indels.
+
+    Args:
+        cigar_str (str): cigar_string
+        sequence1(str): aligned sequence 1 to be trimmed
+        sequence2(str): aligned sequence 2 to be trimmed
+    Returns:
+        str: trimmed sequence 1
+        str: trimmed sequence 2
+    """
+
+    prefix_indels, suffix_indels = get_prefix_and_suffix_indels(cigar_str)
+
+    if len(prefix_indels) == 0 and len(suffix_indels) == 0:
+        return sequence1, sequence2
+    global total_trim
+    total_trim += 1
+    # print("Prefix and suffix indels:", prefix_indels, suffix_indels)
+
+    # print("Before trimming:", len(sequence1), len(sequence2))
+
+    prefix_type = ""
+    prefix_length = 0
+    if len(prefix_indels) != 0:
+        for edit in prefix_indels:
+            if prefix_type != "":
+                assert prefix_type == edit[-1]
+            else:
+                prefix_type = edit[-1]
+            prefix_length += len(edit[:-1])
+
+    suffix_type = ""
+    suffix_length = 0
+    if len(suffix_indels) != 0:
+        for edit in suffix_indels:
+            if suffix_type != "":
+                assert suffix_type == edit[-1]
+            else:
+                suffix_type = edit[-1]
+            suffix_length += len(edit[:-1])
+
+    sequence1 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence1, 1)
+    sequence2 = trim_seq(prefix_type, prefix_length, suffix_type, suffix_length, sequence2, 2)
+
+    global correct_trim
+    if len(sequence1) == len(sequence2):
+        correct_trim += 1
+
+    # print("After trimming:", len(sequence1), len(sequence2))
+
+    return sequence1, sequence2
+
+    
+
+total_trim = 0
+
+input_dir = "/Users/yutongq/SVHackathon2022/"
+fname = input_dir+"unique_isoforms_and_aln_stats.tsv"
+
+
+"""Header
+    win_chr
+    win_start
+    win_end
+    total_isoform
+    isoform_name
+    sample_from
+    sample_compared_to
+    mapped_start
+    isoform_sequence
+    selected_alignments
+"""
+aln_stats_df = pd.read_csv(fname, sep="\t").dropna()
+
+'''
+    For each sample:
+        for each read in sample:
+            will there be multiple reads that are associated with each other?
+'''
+
+records = aln_stats_df.to_dict("records")
+
+unique_read_pairs = defaultdict(dict)             # {read_id1: {read_id2: edit distance}}
+read_pair_cigar = defaultdict(dict)               # {read_id1: {read_id2: cigar_string}}
+read_sequence = dict()                            # {read_id: sequence}
+
+for record in records:
+    read_id = record["sample_from"] + "_" + record["isoform_name"]
+    compared_to= "_".join(record["selected_alignments"].split("_")[1:3])
+    cigar = record["selected_alignments"].split("_")[-1]
+
+    read_sequence[read_id] = record["isoform_sequence"]
+
+    # # check if read_id, compared_to pair is already accounted for.
+    # if compared_to in unique_read_pairs and read_id in unique_read_pairs[compared_to]:
+    #     continue
+
+    if compared_to not in unique_read_pairs[read_id]:
+        read_pair_cigar[read_id][compared_to] = cigar
+        unique_read_pairs[read_id].add(compared_to)
+
+multi_pair = Counter()
+unique_pair_cigar = defaultdict(dict)
+
+correct_trim = 0
+
+# print(read_pair_cigar)
+for read_id in unique_read_pairs:
+    multi_pair[len(unique_read_pairs[read_id])] += 1
+
+    if len(unique_read_pairs[read_id]) == 1:
+        for compared_to in unique_read_pairs[read_id]:
+                cigar = read_pair_cigar[read_id][compared_to]
+                seq1 = read_sequence[read_id]
+                try:
+                    seq2 = read_sequence[compared_to]
+                except KeyError:
+                    break
+                new_seq1, new_seq2 = trim_from_cigar(cigar, seq1, seq2)
+                old_ed = ed_from_cigar(read_pair_cigar[read_id][compared_to])
+                ## TODO new_ed = 
+                break
+
+
+print("total trim:", total_trim)
+print("Correct trim:", correct_trim)
+
+
+    
+
+    # if len(unique_read_pairs[r]) > 1:
+    #     eds = []
+    #     for compared_to in unique_read_pairs[r]:
+    #         print(r,compared_to+",")
+    #         ed = ed_from_cigar(read_pair_cigar[r][compared_to])
+    #         eds.append(ed)
+    #     print(eds)
+print("Multi pair", multi_pair)

--- a/scripts/trim_indel_ends.py
+++ b/scripts/trim_indel_ends.py
@@ -380,11 +380,10 @@ def main(manifest, unique_isoform_aln, mode, threshold):
     fig, ax = plt.subplots(1)
     ax.scatter(old_eds, new_eds, s=5)
     ax.plot([0, max(old_eds)], [0, max(old_eds)], color="red")
-    ax.set_xrange(0, 20)
     ax.set_xlabel("original edit distance")
     ax.set_ylabel("timmed edit distance")
     ax.set_title("Edit distance before and after trimming")
-    fig.savefig("ED_trim_%s_%s.png" % (mode, str(threshold)))
+    fig.savefig("ED_trim_scatter_%s_%s.png" % (mode, str(threshold)))
     print("Scatterplot saved to ED_trim_%s_%s.png" % (mode, str(threshold)))
 
 
@@ -396,7 +395,7 @@ def main(manifest, unique_isoform_aln, mode, threshold):
     ax.set_ylabel("Number of sequences")
     ax.legend()
 
-    fig.savefig("ED_trim_length_%s_%s.png" % (mode, str(threshold)))
+    fig.savefig("ED_trim_length_distribution_%s_%s.png" % (mode, str(threshold)))
     print("Histogram saved to ED_trim_length_%s_%s.png" % (mode, str(threshold)))
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This program looks at pair-wise isoform alignments within each window and trims off beginning and ending of isoforms to reduce false posistives.

## Help message
`python scripts/trim_indel_ends.py manifest unique_isoform_aln [-m mode -t threshold]`

```
- manifest -- manifest file in form <sample,in/fasta.fa> that describes the sample and location of fasta files
- unique_isoform_aln -- output from `find_unique_isoform.py`
- mode -- optional -- "strict" or "lenient"
    - "strict" will only trim if after trimming, two isoforms are exactly the same
    - "lenient" will trim whenever indels are encountered at the ends of the alignment
    - Default is "lenient"
- threshold -- optional -- maximum number of bases to be trimmed off each end. Default is 10000 (no limit)
```

## Some simple stats about trimming:
If there is no threshold (threshold = 10000)
- maximum trim length is 5000 (which doesn't make sense so a threshold is definitely needed.) 
- Among a total of 70859 isoform pairs, 19914 were trimmed. Among them, 5238 pairs are identical after trimming.
If threshold=10 (each side can trim 10 bases off)
- 4050 pairs are identical after trimming

Figure below shows when threshold = 10000, edit distance between pairs of isoforms before and after trimming. Each dot is a pair of isoforms
![ED_trim](https://user-images.githubusercontent.com/9258097/203834943-5b9894be-240c-459a-b89e-ee8154319f0d.png)

Figure below shows then threshold = 10000, distribution of actual trim lengths. Orange is when edit distance is still not 0. Shaded area (blue) represents pairs where ED becomes 0.
![ED_trim_length_distribution_lenient_10000](https://user-images.githubusercontent.com/9258097/203835120-e44cd116-4c20-4336-be74-086c96bc880e.png)


## Input
- fasta files for each sample
- `unique_isoform_and_aln_stats.tsv` produced by `find_unique_isoform.py`

## Output
- separate sample fasta files
- Histogram describing trim lengths
- Scatter plot describing edit distance before and after trimmming

## Logic
1. For each isoform present in `unique_isoform_and_aln_stats.tsv`, this program first finds the isoform in another sample that is the most similar to it. 

2. Then, this program looks at the cigar string of each pair of sequences. 
    - If the cigar string starts or ends with insertions `"I"` or deletions `"D"`, the program trims the sequences.
        - Trim the first-in-pair if `"I"` is encountered
        - Trim the second-in-pair if `"D"` is encountered
3. Write sequences in separate sample fasta files
    - If a sequence is trimmed in multiple pairs, keep the longest one
    - If a sequence is not included in `unique_isoform_and_aln_stats.tsv`, look for it in original fasta and include it.